### PR TITLE
:bug: syntax error corrections

### DIFF
--- a/sources/-command-.zsh
+++ b/sources/-command-.zsh
@@ -11,4 +11,5 @@ case $group in
     ;;
   parameter)
     echo ${(P)word}
+    ;;
 esac

--- a/sources/git-checkout.zsh
+++ b/sources/git-checkout.zsh
@@ -4,8 +4,7 @@ case $group in
     git diff $word | delta
     ;;
   'recent commit object name')
-    git log --color=always $word | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json)
-    | delta
+    git log --color=always $word | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json) | delta
     ;;
   *)
     git log --color=always $word | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json)

--- a/sources/git-reflog.zsh
+++ b/sources/git-reflog.zsh
@@ -1,9 +1,9 @@
 # :fzf-tab:complete:git-reflog(|-*):argument-1
 case $group in
   command)
-    git reflog --color=always show | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json
+    git reflog --color=always show | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json)
     ;;
   reference)
-    git reflog --color=always $word | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json
+    git reflog --color=always $word | perl -pe$(jq -j '.[] as $i | "s=" + $i.code + "=" + $i.emoji + "=g;"' ~/.gitmoji/gitmojis.json)
     ;;
 esac

--- a/sources/pygmentize.zsh
+++ b/sources/pygmentize.zsh
@@ -2,6 +2,7 @@
 case $group in
   L)
     pygmentize -L $word | bat --color=always -plrst
+    ;;
   *)
     [[ -f ${realpath#--*=} ]] && pygmentize ${realpath#--*=} || less ${realpath#--*=}
     ;;

--- a/sources/run-help.zsh
+++ b/sources/run-help.zsh
@@ -1,9 +1,12 @@
 # :fzf-tab:complete:(\\|)run-help:argument-rest
-# Note run-help usually is an alias, remember:
+# NOTE: `run-help` is an alias of `man` in zsh by default,
+# which means `run-help` will use `man`'s completion.
+# you must add the following code to your `~/.zshrc` to enable and unalias it:
 #
 # ```zsh
-# (($+aliases[run-help]))
-    && unalias run-help
-# autoload -Uz run-help
+# autoload -Uz run-help && (($+aliases[run-help])) && unalias run-help
 # ```
+#
+# true `run-help` can display the help of zsh built-in commands
+# while `man` can display the help of external commands
 run-help $word


### PR DESCRIPTION
* did some minor changes cause the files threw syntax errors

git-checkout.zsh, git-reflog and pygmentize should be clear. iam not so sure about run-help

## zsh 5.9 (x86_64-debian-linux-gnu)

* git-checkout.zsh
`zsh ~/.zgenom/Freed-Wu/fzf-tab-source/___/sources/git-checkout.zsh`
```ShellSession
 /home/sgrewe/.zgenom/Freed-Wu/fzf-tab-source/___/sources/git-checkout.zsh:8: parse error near `|'
```

* git-reflog.zsh
`zsh ~/.zgenom/Freed-Wu/fzf-tab-source/___/sources/git-reflog.zsh`
```ShellSession
/home/sgrewe/.zgenom/Freed-Wu/fzf-tab-source/___/sources/git-reflog.zsh:5: parse error near `;;'
/home/sgrewe/.zgenom/Freed-Wu/fzf-tab-source/___/sources/git-reflog.zsh:6: parse error near `-pe$(jq -j '.[] as $...'
```

* pygmentize.zsh
`zsh ~/.zgenom/Freed-Wu/fzf-tab-source/___/sources/pygmentize.zsh`
```ShellSession
/home/sgrewe/.zgenom/Freed-Wu/fzf-tab-source/___/sources/pygmentize.zsh:5: parse error near `)'
```

* run-help.zsh
`zsh ~/.zgenom/Freed-Wu/fzf-tab-source/___/sources/run-help.zsh`
```ShellSession
/home/sgrewe/.zgenom/Freed-Wu/fzf-tab-source/___/sources/run-help.zsh:6: parse error near `&&'
```