### PR TITLE
🐛Fix variables visible in shell

### DIFF
--- a/fzf-tab-source.plugin.zsh
+++ b/fzf-tab-source.plugin.zsh
@@ -2,31 +2,33 @@
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 
-local dir=${0:h} config_directory
-zstyle -s ':fzf-tab:sources' config-directory config_directory
-local sources=($dir/sources/*.zsh)
-# use user's sources to override this plugin's sources
-if [[ -n $config_directory ]]; then
-  sources+=($config_directory/**/*.zsh(.N))
-fi
-
-# https://github.com/Freed-Wu/fzf-tab-source/issues/11
-# enable $group
-zstyle ':completion:*:descriptions' format %d
-
-local src line arr ctx flags
-for src in $sources; do
-  while read -r line; do
-    # strip code to get magic comment
-    arr=(${(@s. .)line##\# })
-    ctx=${arr[1]}
-    if [[ $ctx == ':fzf-tab:'* ]]; then
-      break
-    fi
-  done < $src
-  zstyle $ctx fzf-preview "src="\""$src"\"" . "\""$dir"\""/functions/main.zsh"
-  flags=${arr[2]}
-  if [[ -n $flags ]]; then
-    zstyle $ctx fzf-flags $flags
+function () {
+  local dir=${1:h} config_directory
+  zstyle -s ':fzf-tab:sources' config-directory config_directory
+  local sources=($dir/sources/*.zsh)
+  # use user's sources to override this plugin's sources
+  if [[ -n $config_directory ]]; then
+    sources+=($config_directory/**/*.zsh(.N))
   fi
-done
+
+  # https://github.com/Freed-Wu/fzf-tab-source/issues/11
+  # enable $group
+  zstyle ':completion:*:descriptions' format %d
+
+  local src line arr ctx flags
+  for src in $sources; do
+    while read -r line; do
+      # strip code to get magic comment
+      arr=(${(@s. .)line##\# })
+      ctx=${arr[1]}
+      if [[ $ctx == ':fzf-tab:'* ]]; then
+        break
+      fi
+    done < $src
+    zstyle $ctx fzf-preview "src="\""$src"\"" . "\""$dir"\""/functions/main.zsh"
+    flags=${arr[2]}
+    if [[ -n $flags ]]; then
+      zstyle $ctx fzf-flags $flags
+    fi
+  done
+} $0


### PR DESCRIPTION
Currently, variables that are used in the sourced script are still present in the shell after sourcing fzf-tab-sources. This is due to the fact that the script is sourced. Using local for the variables has no effect that way.
I found that this causes programs that use the src var, like for example nix-shell to print src=<the new src variable> instead of just being quiet about that. All in all I would say it's better to keep the user's shell clean.

This patch introduces an init function to restrict the scope of the variables. I think that this is the best solution since every variable is just isolated by default. Though I haven't checked how other plugins deal with this.

Thanks for this project, it's pretty cool!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **Refactor**
	- Improved the initialization process of a plugin for better setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->