### PR TITLE
🐛Fix systemctl invocation

### DIFF
--- a/sources/systemctl-cat.zsh
+++ b/sources/systemctl-cat.zsh
@@ -1,2 +1,2 @@
 # :fzf-tab:complete:systemctl-cat:*
-systemctl cat $word | bat -lini
+SYSTEMD_COLORS=false systemctl cat -- $word | bat -lini

--- a/sources/systemctl-help.zsh
+++ b/sources/systemctl-help.zsh
@@ -1,2 +1,2 @@
 # :fzf-tab:complete:systemctl-help:*
-systemctl help $word 2>/dev/null | bat -lhelp
+systemctl help -- $word 2>/dev/null | bat -lhelp

--- a/sources/systemctl-list-dependencies.zsh
+++ b/sources/systemctl-list-dependencies.zsh
@@ -1,6 +1,6 @@
 # :fzf-tab:complete:(\\|*/|)systemctl-list-dependencies:*
 case $group in
 unit)
-  systemctl list-dependencies $word
+  systemctl list-dependencies -- $word
   ;;
 esac

--- a/sources/systemctl-status.zsh
+++ b/sources/systemctl-status.zsh
@@ -1,2 +1,2 @@
 # :fzf-tab:complete:systemctl-(status|(re|)start|(dis|en)able):*
-systemctl status $word
+systemctl status -- $word


### PR DESCRIPTION
I found two issues with the current systemctl invocations:
- systemctl cat includes colors which are not parsed by bat. This leads to some numbers in the output of that preview.
- systemctl is called without -- before the argument/target. This causes issues with units on my system that start with -. I don't know if these units should be there, but it's a good practice to add --.

For the second issue I am pretty sure that there are other cases where -- should get added for above explained reasons. But note that this can also be a security issue since we are basically passing an untrusted [1] file name to a command. An attacker could craft a malicious zip archive with rogue file names.

So I would suggest it's best if we would add -- everywhere and then just check where it fails (most commands support it). 

[1]: This depends on how you deal with untrusted archives/directories. When you often download stuff from the internet, let's say a zip archive, and then extract that, it could in theory happen that one of the files has a file name in the form of `--rogue-argument`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved command syntax in the system control utility for more reliable output display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->