### PR TITLE
:bug: Fix #17, support darwin's ps

### DIFF
--- a/sources/ps.zsh
+++ b/sources/ps.zsh
@@ -1,3 +1,6 @@
 # :fzf-tab:complete:(\\|*/|)(kill|ps):argument-rest --preview-window=down:3:wrap
+if [[ $OSTYPE == darwin* ]]; then
+  alias -g -- --no-headers='| tail -n1'
+fi
 [[ $group == 'process ID' ]] &&
-  ps -p$word -wocmd --no-headers | bat -lsh
+  ps -p$word -wocommand --no-headers | bat -lsh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved `ps` command compatibility across different operating systems by adding a conditional OS check.
	- Modified `ps` command to use `wocommand` instead of `wocmd.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->