### PR TITLE
use yay if installed to see package information

### DIFF
--- a/sources/pacman.zsh
+++ b/sources/pacman.zsh
@@ -1,4 +1,4 @@
-# :fzf-tab:complete:(\\|*/|)(pacman|yay):(argument-(rest|1)|option-l-1)
+# :fzf-tab:complete:(\\|*/|)(pacman|paru|yay):(argument-(rest|1)|option-l-1)
 case $group in
 'package file')
   less $realpath
@@ -7,6 +7,12 @@ case $group in
   pacman -Qi $word | bat -lyaml
   ;;
 packages)
-  pacman -Si $word | bat -lyaml
+  if (($+commands[paru])); then
+    paru -Si $word | bat -lyaml
+  elif (($+commands[yay])); then
+    yay -Si $word | bat -lyaml
+  else
+    pacman -Si $word | bat -lyaml
+  fi
   ;;
 esac


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package management flexibility by allowing the use of the `yay` package manager as an alternative to `pacman` for retrieving package information.
	- Improved command execution based on the availability of the `yay` package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->