### PR TITLE
Add support for batcat in Debian derived distributions

### DIFF
--- a/functions/main.zsh
+++ b/functions/main.zsh
@@ -2,7 +2,15 @@
 # treat bat -lXXX as cat
 # currently, only bat supports highlight --help
 alias -g -- "--help=\\--help | bat -lhelp"
-(($+commands[bat])) && bat() {command bat --color=always -p $@} || bat() {command cat}
+
+if (($+commands[bat])); then
+  bat() {command bat --color=always -p $@}
+elif (($+commands[batcat])); then
+  bat() {command batcat --color=always -p $@}
+else
+  bat() {command cat}
+fi
+
 if ((! $+commands[mdcat])); then
   if (($+commands[paper])); then
     mdcat() {command paper $@}
@@ -13,12 +21,15 @@ if ((! $+commands[mdcat])); then
     mdcat() {bat -lmarkdown}
   fi
 fi
+
 if ((! $+commands[finger])); then
   (($+commands[pinky])) && finger() {command pinky $@} ||
     finger() {command whoami}
 fi
+
 (($+commands[pandoc])) || pandoc() {command cat ${@[-1]}}
 (($+commands[grc])) || grc() {eval ${@[2,-1]}}
+
 # https://github.com/Freed-Wu/fzf-tab-source/issues/6
 if (($+commands[less])) && [ -x ~/.lessfilter ]; then
   less() {~/.lessfilter $@ || command less $@}

--- a/sources/bat.zsh
+++ b/sources/bat.zsh
@@ -1,4 +1,4 @@
-# :fzf-tab:complete:(\\|*/|)bat:argument-rest
+# :fzf-tab:complete:(\\|*/|)bat(|cat):argument-rest
 case $group in
 subcommand)
   bat cache --help


### PR DESCRIPTION
On Debian/Ubuntu distributions, `bat` is renamed to `batcat` to avoid a name collision. This pr adds an additional check and source for `batcat`.

Also the alias here does not create a global alias does not call `bat` when adding `--help` in commands.
https://github.com/Freed-Wu/fzf-tab-source/blob/4d6a57840907b1970f0e41901059eee35c9809db/functions/main.zsh#L4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced file-display commands with improved fallback options to better support various system environments.
  - Introduced dynamic completion that offers context-aware guidance and help when using commands.
- **Refactor**
  - Streamlined the internal conditional logic for clearer structure and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->