### PR TITLE
Add glow as an available markdown renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ You need some optional tools:
 - [pandoc](https://github.com/jgm/pandoc): convert any kind of file to
   markdown. Any generated cache file will be store in same
   `/tmp/zsh-fzf-tab-$USER` as [fzf-tab](https://github.com/Aloxaf/fzf-tab)
-- render markdown: Refer
-  <https://github.com/foxfriends/paper-terminal#comparison-with-other-command-line-markdown-renderers>
+- render markdown:
+  - [mdcat](https://github.com/swsnr/mdcat): unmaintained
+  - [mdless](https://github.com/ttscoff/mdless)
+  - [paper](https://github.com/foxfriends/paper-terminal)
+  - [glow](https://github.com/charmbracelet/glow)
 - [grc](https://github.com/garabik/grc): colorize the output of some commands
 - [less](https://github.com/vbwagner/less): a pager
 

--- a/functions/main.zsh
+++ b/functions/main.zsh
@@ -16,6 +16,8 @@ if ((! $+commands[mdcat])); then
     mdcat() {command paper $@}
   elif (($+commands[mdless])); then
     mdcat() {command mdless $@}
+  elif (($+commands[glow])); then
+    mdcat() {command glow $@}
   else
     # use bat() as fallback
     mdcat() {bat -lmarkdown}

--- a/sources/glow.zsh
+++ b/sources/glow.zsh
@@ -1,0 +1,2 @@
+# :fzf-tab:complete:(\\|*/|)glow:argument-rest
+[[ -f $realpath ]] && glow $realpath || less $realpath


### PR DESCRIPTION
This adds https://github.com/charmbracelet/glow to the list of renderers to be selected. `glow` does provides its own completion for commands but the source is copied from `mdcat/mdless`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated markdown rendering instructions with a detailed list of tool options, providing clearer guidance on how to render markdown content.

- **New Features**
  - Enhanced command-line utilities to dynamically select the best available tool for content display, ensuring a smoother viewing experience.
  - Introduced improved tab-completion support for `glow` and `batcat`, delivering context-based suggestions to streamline command-line usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->