### PR TITLE
Add help preview for chezmoi

### DIFF
--- a/sources/chezmoi.zsh
+++ b/sources/chezmoi.zsh
@@ -1,0 +1,2 @@
+# :fzf-tab:complete:(\\|*/|)chezmoi:
+chezmoi $word --help


### PR DESCRIPTION
This adds [chezmoi](https://www.chezmoi.io/) as a source for fzf and preview the usage for its completion. Based off pipx's source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced shell auto-completion for the `chezmoi` command. Now, when using tab completion, users receive suggestions that include immediate access to help documentation, streamlining the terminal experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->