### PR TITLE
Improve git commands support

### DIFF
--- a/sources/git-add.zsh
+++ b/sources/git-add.zsh
@@ -1,9 +1,9 @@
 # :fzf-tab:complete:git-(add|restore):argument-rest
 case $group in
 "untracked file")
-  less ${realpath#-*=}
+  less ${realpath#--*=}
   ;;
 *)
-  git diff --color=always ${realpath#-*=}
+  git diff --color=always ${realpath#--*=}
   ;;
 esac

--- a/sources/git-add.zsh
+++ b/sources/git-add.zsh
@@ -1,0 +1,9 @@
+# :fzf-tab:complete:git-(add|restore):argument-rest
+case $group in
+"untracked file")
+  less ${realpath#-*=}
+  ;;
+*)
+  git diff --color=always ${realpath#-*=}
+  ;;
+esac

--- a/sources/git-branch.zsh
+++ b/sources/git-branch.zsh
@@ -1,0 +1,2 @@
+# :fzf-tab:complete:git-(branch|switch):argument-1
+git log --color=always $word

--- a/sources/git-diff.zsh
+++ b/sources/git-diff.zsh
@@ -1,9 +1,9 @@
 # :fzf-tab:complete:git-(diff|cherry-pick):argument-rest
 case $group in
-'tree file')
+*'tree file')
   less ${realpath#--*=}
   ;;
 *)
-  git diff $realpath
+  git diff $word
   ;;
 esac


### PR DESCRIPTION
Improve git commands support :
- Fix `git diff` preview
  -  group name "changed in working tree file"
  -  git diff should use $word
- Support for `git add` and `git restore`, preview `git diff` for tracked files and `less` for untracked files
- Support for `git branch` and `git switch`, preview `git log` of branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive shell completions for add/restore workflows with file previews and content viewing
  * Completion for branch/switch commands showing colored commit history as candidates

* **Improvements**
  * Broadened pattern matching in diff completion and corrected target handling for more accurate diff results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->